### PR TITLE
common: Allow system_app to read fm_radio_device

### DIFF
--- a/legacy/vendor/common/system_app.te
+++ b/legacy/vendor/common/system_app.te
@@ -133,6 +133,7 @@ allow system_app serial_device:chr_file rw_file_perms;
 unix_socket_connect(system_app,bluetooth, bluetooth)
 # access  wcnss_filter from fm app
 #allow system_app wcnss_filter:unix_stream_socket connectto;
+allow system_app fm_radio_device:chr_file r_file_perms;
 
 # ANR
 allow system_app anr_data_file:dir r_dir_perms;


### PR DESCRIPTION
* This was moved to platform_app in c0d7a5ce1d593f6bc5cb8bef8a108e9ec04cd51d, but AOSP FM app is still system_app

Fixes:
I auditd  : type=1400 audit(0.0:74): avc: denied { read } for comm="android.fmradio" uid=1000 name="radio0" dev="tmpfs" ino=15585 scontext=u:r:system_app:s0 tcontext=u:object_r:fm_radio_device:s0 tclass=chr_file permissive=0

Signed-off-by: Jarl-Penguin <jarlpenguin@outlook.com>
Change-Id: I9f662803390697b9456d18a4186ee7d7d6ac2e50